### PR TITLE
Capture multiple lemma options

### DIFF
--- a/syntaxes/tamarin.tmLanguage.xml
+++ b/syntaxes/tamarin.tmLanguage.xml
@@ -129,7 +129,7 @@
 
       <dict>
          <key>match</key>
-         <string>(lemma)\s+(\w+)\s*(?:\[(?:(sources|use_induction|reuse)|(?:(hide_lemma)=\w+))\])?\s*:</string>
+         <string>(lemma)\s+(\w+)\s*(?:\[(?:(sources|use_induction|reuse)|(?:(hide_lemma)=\w+)|,)*\])?\s*:</string>
          <key>captures</key>
          <dict>
             <key>1</key>


### PR DESCRIPTION
Prior to this change, VS code would not recognize lemmata with multiple keywords, e.g., `lemma Lemma[reuse,use_induction]:`.

I deliberately went for a simpler regex that also might capture bad syntax, e.g., `lemma Lemma[,]`, in favor of repitition.